### PR TITLE
Update kolibri-installer-gnome

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -55,7 +55,7 @@ modules:
       - type: git
         url: https://github.com/learningequality/kolibri-installer-gnome.git
         # branch: master
-        commit: a839bd8053af97e8ccdcc5dc25481eecdf43af8c
+        commit: 77397c3a626f2ffbeb4695c3414935278c5cb761
 
   - name: kolibri-home-template
     buildsystem: simple


### PR DESCRIPTION
This includes a fix for locale directory names.