### PR TITLE
Remove unnecessary files in kolibri/dist

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -28,6 +28,21 @@ modules:
       - pip3 install --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} kolibri
       - install -d ${FLATPAK_DEST}/libexec
       - mv ${FLATPAK_DEST}/bin/kolibri ${FLATPAK_DEST}/libexec/kolibri
+    cleanup:
+      - /lib/python3.7/site-packages/kolibri/dist/cext/cp27
+      - /lib/python3.7/site-packages/kolibri/dist/cext/cp34
+      - /lib/python3.7/site-packages/kolibri/dist/cext/cp35
+      - /lib/python3.7/site-packages/kolibri/dist/cext/cp36
+      - /lib/python3.7/site-packages/kolibri/dist/cext/cp37/Windows
+      - /lib/python3.7/site-packages/kolibri/dist/cheroot/test
+      - /lib/python3.7/site-packages/kolibri/dist/cherrypy/test
+      - /lib/python3.7/site-packages/kolibri/dist/Cryptodome/SelfTest
+      - /lib/python3.7/site-packages/kolibri/dist/django_js_reverse/tests
+      - /lib/python3.7/site-packages/kolibri/dist/future/backports/test
+      - /lib/python3.7/site-packages/kolibri/dist/more_itertools/tests
+      - /lib/python3.7/site-packages/kolibri/dist/py2only
+      - /lib/python3.7/site-packages/kolibri/dist/sqlalchemy/testing
+      - /lib/python3.7/site-packages/kolibri/dist/tzlocal/test_data
     sources:
       - type: file
         url: https://storage.googleapis.com/le-downloads/kolibri-0.13.3a0.dev0%2Bgit.62.g5d05c61b-py2.py3-none-any.whl


### PR DESCRIPTION
This change removes unused compiled c extensions in kolibri/dist/cext,
as well as standalone test suites over 100 KB.

#6