### PR TITLE
Optimize content import depending on changes

### DIFF
--- a/kolibri-flatpak-utils/kolibri_wrapper.py
+++ b/kolibri-flatpak-utils/kolibri_wrapper.py
@@ -6,17 +6,107 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import datetime
-import operator
 import os
 import subprocess
 import sys
 
-from kolibri_gnome.globals import init_logging
+from kolibri_gnome.globals import KOLIBRI_HOME, init_logging
 
 from .content_extensions import ContentExtensionsList
 
 KOLIBRI = "/app/libexec/kolibri"
+
+
+class KolibriContentOperation(object):
+    def apply(self, run_kolibri_fn):
+        raise NotImplementedError()
+
+    @classmethod
+    def from_channel_compare(cls, channel_compare):
+        if channel_compare.added:
+            logger.info("Channel added %s", channel_compare.channel_id)
+            logger.info("include_node_ids %s", channel_compare.new_include_node_ids)
+            logger.info("exclude_node_ids %s", channel_compare.new_exclude_node_ids)
+            yield KolibriContentOperation_ImportChannel(
+                channel_id=channel_compare.channel_id
+            )
+            yield KolibriContentOperation_ImportContent(
+                channel_id=channel_compare.channel_id,
+                include_node_ids=channel_compare.new_include_node_ids,
+                exclude_node_ids=channel_compare.new_exclude_node_ids
+            )
+        elif channel_compare.removed:
+            logger.info("Channel removed %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id,
+                removed=True
+            )
+        elif channel_compare.exclude_nodes_added:
+            # We need to rescan all content in the channel
+            # TODO: Find a way to provide old_exclude_node_ids to
+            #       Kolibri instead of scanning all content.
+            logger.info("Channel update (exclude_nodes_added) %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id
+            )
+        elif channel_compare.include_nodes_removed:
+            # We need to rescan all content in the channel
+            # TODO: Find a way to provide old_include_node_ids to
+            #       Kolibri instead of scanning all content.
+            logger.info("Channel update (include_nodes_removed) %s", channel_compare.channel_id)
+            yield KolibriContentOperation_RescanContent(
+                channel_id=channel_compare.channel_id
+            )
+        else:
+            # Channel content updated, no content removed
+            # We can handle this case efficiently with importcontent
+            logger.info("Channel update (good) %s", channel_compare.channel_id)
+            logger.info("include_node_ids %s", channel_compare.new_include_node_ids)
+            logger.info("exclude_node_ids %s", channel_compare.new_exclude_node_ids)
+            yield KolibriContentOperation_ImportContent(
+                channel_id=channel_compare.channel_id,
+                include_node_ids=channel_compare.new_exclude_node_ids,
+                exclude_node_ids=channel_compare.new_include_node_ids
+            )
+
+
+class KolibriContentOperation_ImportChannel(KolibriContentOperation):
+    def __init__(self, channel_id):
+        self.__channel_id = channel_id
+
+    def apply(self, run_kolibri_fn):
+        logger.info("Running importchannel for %s", self.__channel_id)
+        return run_kolibri_fn("manage", "importchannel", "disk", self.__channel_id, KOLIBRI_HOME)
+
+
+class KolibriContentOperation_ImportContent(KolibriContentOperation):
+    def __init__(self, channel_id, include_node_ids, exclude_node_ids):
+        self.__channel_id = channel_id
+        self.__include_node_ids = include_node_ids
+        self.__exclude_node_ids = exclude_node_ids
+
+    def apply(self, run_kolibri_fn):
+        logger.info("Running importcontent for %s", self.__channel_id)
+        nodes_args = []
+        for include_node_id in self.__include_node_ids:
+            nodes_args.extend(['--node_ids', include_node_id])
+        for exclude_node_id in self.__exclude_node_ids:
+            nodes_args.extend(['--exclude_node_ids', exclude_node_id])
+        return run_kolibri_fn("manage", "importcontent", *nodes_args, "disk", self.__channel_id, KOLIBRI_HOME)
+
+
+class KolibriContentOperation_RescanContent(KolibriContentOperation):
+    def __init__(self, channel_id, removed=False):
+        self.__channel_id = channel_id
+        self.__removed = removed
+
+
+    def apply(self, run_kolibri_fn):
+        logger.info("Running scanforcontent for %s", self.__channel_id)
+        args = []
+        if self.__removed:
+            args.append("--channel-import-mode=none")
+        return run_kolibri_fn("manage", "scanforcontent", "--channels={}".format(self.__channel_id), *args)
 
 
 class Application(object):
@@ -25,92 +115,34 @@ class Application(object):
         self.__active_extensions = ContentExtensionsList.from_flatpak_info()
 
     def run(self):
-        extensions_diff = self.__cached_extensions.diff(self.__active_extensions)
-        process_success = all(
-            [
-                self.__process_removed_extensions(extensions_diff),
-                self.__process_added_extensions(extensions_diff),
-                self.__process_updated_extensions(extensions_diff),
-            ]
+        success = all(
+            operation.apply(self.__run_kolibri) == 0
+            for operation in self.__iter_content_operations()
         )
 
-        if process_success:
+        if success:
             self.__active_extensions.write_to_cache()
 
-        return self.__run_kolibri()
+        args = sys.argv[1:]
+        return self.__run_kolibri(*args)
 
-    def __process_removed_extensions(self, extensions_diff):
-        # For each removed channel, run scanforcontent
-        # TODO: Is there a less expensive way of doing this than scanforcontent?
-        channel_ids = set()
-        for extension in extensions_diff.removed():
-            logging.info("Removed extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids, ["--channel-import-mode=none"])
-
-    def __process_added_extensions(self, extensions_diff):
-        # For each added channel, run scanforcontent
-        # TODO: Instead of scanforcontent, use importcontent with --node_ids and --exclude_node_ids
-        channel_ids = set()
-        for extension in extensions_diff.added():
-            logging.info("Added extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids)
-
-    def __process_updated_extensions(self, extensions_diff):
-        # For each updated channel, run scanforcontent
-        # TODO: Instead of scanforcontent, use importcontent with --node_ids and --exclude_node_ids
-        channel_ids = set()
-        for extension in extensions_diff.updated():
-            logging.info("Updated extension: %s", extension.ref)
-            channel_ids.update(
-                map(operator.attrgetter("channel_id"), extension.channels)
-            )
-        return self.__kolibri_scan_content(channel_ids)
-
-    def __kolibri_scan_content(self, channel_ids, args=[]):
-        if len(channel_ids) == 0:
-            return True
-
-        logger.info(
-            "scanforcontent starting for channels %s: %s",
-            channel_ids,
-            datetime.datetime.today(),
-        )
-
-        try:
-            self.__run_kolibri(
-                [
-                    "manage",
-                    "scanforcontent",
-                    "--channels={}".format(",".join(channel_ids)),
-                    *args,
-                ]
-            )
-        except CalledProcessException as error:
-            logger.warning("scanforcontent failed: %s", datetime.datetime.today())
-            return False
-        else:
-            logger.info("scanforcontent completed: %s", datetime.datetime.today())
-            return True
-
-    def __run_kolibri(self, args=None):
-        if args is None:
-            args = sys.argv[1:]
-        result = subprocess.run([KOLIBRI, *args], env=self.__kolibri_env, check=True)
-        return result.returncode
+    def __iter_content_operations(self):
+        for extension_compare in ContentExtensionsList.compare(self.__cached_extensions, self.__active_extensions):
+            for channel_compare in extension_compare.compare_channels():
+                yield from KolibriContentOperation.from_channel_compare(channel_compare)
 
     @property
     def __kolibri_env(self):
         kolibri_env = os.environ.copy()
         kolibri_env["KOLIBRI_CONTENT_FALLBACK_DIRS"] = ";".join(
-            self.__active_extensions.content_fallback_dirs
+            extension.content_dir for extension in self.__active_extensions
         )
         return kolibri_env
+
+    def __run_kolibri(self, *args):
+        logger.info("run_kolibri %s", args)
+        result = subprocess.run([KOLIBRI, *args], env=self.__kolibri_env, check=True)
+        return result.returncode
 
 
 def main():


### PR DESCRIPTION
This changes the Kolibri wrapper code to use importcontent instead of
scanforcontent when possible, providing a significant performance
improvement when starting Kolibri for the first time with content
extensions installed.