### PR TITLE
Keep C extensions for older versions of Python

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -106,10 +106,12 @@ modules:
       - >
         rm -rf
         /app/lib/python3.7/site-packages/kolibri/dist/cext/cp27
-        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp34
-        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp35
-        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp36
+        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp34/Windows
+        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp35/Windows
+        /app/lib/python3.7/site-packages/kolibri/dist/cext/cp36/Windows
         /app/lib/python3.7/site-packages/kolibri/dist/cext/cp37/Windows
+      - >
+        rm -rf
         /app/lib/python3.7/site-packages/kolibri/dist/cheroot/test
         /app/lib/python3.7/site-packages/kolibri/dist/cherrypy/test
         /app/lib/python3.7/site-packages/kolibri/dist/colorlog/tests


### PR DESCRIPTION
These builds are still compatible with Python 3.7, and Kolibri uses
them.