### PR TITLE
Add Plugin extension

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -13,11 +13,18 @@ finish-args:
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=x11
+  - --env=PYTHONPATH=/app/kolibri-plugins/lib/python
 
 add-extensions:
   org.learningequality.Kolibri.Content:
     version: '1.0'
     directory: share/kolibri-content
+    subdirectories: true
+    no-autodownload: true
+  org.learningequality.Kolibri.Plugin:
+    version: '1.0'
+    directory: kolibri-plugins
+    merge-dirs: lib/python
     subdirectories: true
     no-autodownload: true
 
@@ -78,6 +85,11 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d -m 755 ${FLATPAK_DEST}/share/kolibri-content
+
+  - name: kolibri-plugins-dir
+    buildsystem: simple
+    build-commands:
+      - install -d -m 755 ${FLATPAK_DEST}/kolibri-plugins
 
   - name: python3-kolibri-cleanup
     buildsystem: simple


### PR DESCRIPTION
This new extension point will allow to extend the kolibri app with external flatpaks that just provides new extensions as python modules without the need to update the base app.

This is an example plugin manifest: https://github.com/danigm/org.learningequality.Kolibri.Plugin.Explore/blob/master/org.learningequality.Kolibri.Plugin.Explore.json