### PR TITLE
Add Plugin extension

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -16,11 +16,18 @@ finish-args:
   - --system-talk-name=org.learningequality.Kolibri.Daemon
   - --env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri/data/kolibri
   - --env=KOLIBRI_HTTP_PORT=0
+  - --env=PYTHONPATH=/app/kolibri-plugins/lib/python
 
 add-extensions:
   org.learningequality.Kolibri.Content:
     version: '1.0'
     directory: share/kolibri-content
+    subdirectories: true
+    no-autodownload: true
+  org.learningequality.Kolibri.Plugin:
+    version: '1.0'
+    directory: kolibri-plugins
+    merge-dirs: lib/python
     subdirectories: true
     no-autodownload: true
 
@@ -87,6 +94,11 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d -m 755 ${FLATPAK_DEST}/share/kolibri-content
+
+  - name: kolibri-plugins-dir
+    buildsystem: simple
+    build-commands:
+      - install -d -m 755 ${FLATPAK_DEST}/kolibri-plugins
 
   - name: python37-python38-migration-symlink
     buildsystem: simple


### PR DESCRIPTION
This new extension point will allow to extend the kolibri app with external flatpaks that just provides new extensions as python modules without the need to update the base app.

This is an example plugin manifest: https://github.com/danigm/org.learningequality.Kolibri.Plugin.Explore/blob/master/org.learningequality.Kolibri.Plugin.Explore.json

This is a rebased version of this one #19 