### PR TITLE
Create a symlink for assets loaded from python3.7 Kolibri

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -83,6 +83,12 @@ modules:
     build-commands:
       - install -d -m 755 ${FLATPAK_DEST}/share/kolibri-content
 
+  - name: python37-python38-migration-symlink
+    buildsystem: simple
+    build-commands:
+      - install -d -m 755 /app/lib/python3.7/site-packages
+      - ln -s /app/lib/python3.8/site-packages/kolibri /app/lib/python3.7/site-packages/kolibri
+
   - name: python3-kolibri-cleanup
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This is a temporary quick fix for an issue where existing Kolibri
installs create symbolic links for assets leading to python3.7-specific
paths. These links broke with the update to python3.8.