### PR TITLE
Update the version of pytz included with Kolibri

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -37,6 +37,8 @@ modules:
 
   - python3-kolibri.json
 
+  - python3-kolibri-pytz.json
+
   - name: kolibri-home-template
     buildsystem: simple
     build-options:

--- a/python3-kolibri-pytz.json
+++ b/python3-kolibri-pytz.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pytz",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" pytz==2020.5 --upgrade --target=\"/app/lib/python3.8/site-packages/kolibri/dist/\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/89/06/2c2d3034b4d6bf22f2a4ae546d16925898658a33b4400cfb7e2c1e2871a3/pytz-2020.5-py2.py3-none-any.whl",
+            "sha256": "16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"
+        }
+    ]
+}


### PR DESCRIPTION
See also learningequality/kolibri#7760.

The dependency will be updated in Kolibri 0.14.7, but this change makes
this fix available for Kolibri users as soon as possible.