### PR TITLE
Update kolibri-installer-gnome to 8eb89c7

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --socket=x11
   - --system-talk-name=org.learningequality.Kolibri.Daemon
   - --env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri/data/kolibri
+  - --env=KOLIBRI_HTTP_PORT=0
 
 add-extensions:
   org.learningequality.Kolibri.Content:
@@ -76,7 +77,7 @@ modules:
       - type: git
         url: https://github.com/learningequality/kolibri-installer-gnome.git
         # branch: master
-        commit: ea97193d21485fd9d9d52df684c2ea34b5a777bc
+        commit: 8eb89c7645170bb8782839036ae00c8033f7c099
 
   - name: kolibri-content-dir
     buildsystem: simple


### PR DESCRIPTION
This contains the following changes:

- Set a short inactivity timeout for the desktop application so it does not appear to hang when the user presses triggers the Quit action, for example by pressing Ctrl+Q.
- Periodically clean up finished processes in kolibri-daemon. These would appear as zombie processes for as long as kolibri-daemon runs, which was disconcerting.
- Fix kolibri-daemon wasting CPU time by constantly polling for changes instead of waiting for a signal.
- Allow overriding the port number used by Kolibri by setting the `KOLIBRI_HTTP_PORT` environment variable. Note that the port number set in Kolibri's `options.ini` is (unfortunately) always ignored. For example, to configure Kolibri so it will always run on port 9090, a user could run `flatpak override org.learningequality.Kolibri --env=KOLIBRI_HTTP_PORT=9090`.