### PR TITLE
Install kolibri-app-desktop-xdg-plugin from pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Flatpak packaging for kolibri-installer-gnome
 
 This package contains [Kolibri](https://learningequality.org/kolibri/) as well
-as a GNOME front-end. To build and install this package on your system, use
-flatpak-builder…
+as a GNOME front-end.
+
+## Building
+
+To build and install this package on your system, use flatpak-builder:
 
     flatpak-builder build-dir org.learningequality.Kolibri.yaml --install --user
 
@@ -16,3 +19,20 @@ database files will be stored in the Flatpak application's data directory, such
 as `~/.var/app/org.learningequality.Kolibri/data/kolibri`. This can be changed
 as usual by setting the `KOLIBRI_HOME` environment variable.
 
+## Running Kolibri management commands
+
+You can use the `kolibri` command inside the flatpak to run management commands. For example:
+
+    flatpak run --command=kolibri org.learningequality.Kolibri manage listchannels
+
+For information about Kolibri's management commands, please see <https://kolibri.readthedocs.io/en/latest/manage/command_line.html>.
+
+## Adding desktop launchers for Kolibri channels
+
+Kolibri generates desktop launchers as convenient shortcuts to specific channels you have installed. If you would like for these launchers to appear on your desktop, add `$HOME/.var/app/org.learningequality.Kolibri/data/kolibri/content/xdg/share` to your `XDG_DATA_DIRS`.
+
+To achieve this for all users, create a file named `/usr/lib/systemd/user-environment-generators/61-kolibri-app-desktop-xdg-plugin` with the following contents, then log out and log in again:
+
+    #!/bin/bash
+    XDG_DATA_DIRS="$HOME/.var/app/org.learningequality.Kolibri/data/kolibri/content/xdg/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -40,6 +40,8 @@ modules:
 
   - python3-kolibri-pytz.json
 
+  - python3-kolibri-app-desktop-xdg-plugin.json
+
   - name: kolibri-home-template
     buildsystem: simple
     build-options:
@@ -79,7 +81,7 @@ modules:
       - type: git
         url: https://github.com/learningequality/kolibri-installer-gnome.git
         # branch: master
-        commit: 8eb89c7645170bb8782839036ae00c8033f7c099
+        commit: 1452c0cd48f636a01cfd6c108af58c0fc0499786
 
   - name: kolibri-content-dir
     buildsystem: simple

--- a/python3-kolibri-app-desktop-xdg-plugin.json
+++ b/python3-kolibri-app-desktop-xdg-plugin.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-kolibri-app-desktop-xdg-plugin",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} kolibri-app-desktop-xdg-plugin"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/60/f0/dd2eb7911f948bf529f58f0c7931f6f6466f711bd6f1d81a69dc4edd4e2a/Pillow-8.1.2.tar.gz",
+            "sha256": "b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/c2/a9/35cea6a717587f0c81ff06e189de8a23ee195730d7db69db92cc2961ea3d/kolibri_app_desktop_xdg_plugin-1.0.6-py3-none-any.whl",
+            "sha256": "96d00ef70822bdb12a7955beb637108823da6df99313eeada54534b0f7478e9c"
+        }
+    ]
+}


### PR DESCRIPTION
This should be merged after learningequality/kolibri-installer-gnome#27, with an updated `commit` reference for kolibri-gnome.