### PR TITLE
Default to --format=plain in kolibri-listcontent

### DIFF
--- a/tools/kolibri-listcontent.py
+++ b/tools/kolibri-listcontent.py
@@ -166,7 +166,7 @@ class OutputWriter_Plain(OutputWriter):
                         "+ {id} ({title}) [{kind}]".format(
                             id=node.id,
                             title=click.style(node.title, bold=True),
-                            kind=click.style(_node_kind_str(node), dim=True),
+                            kind=click.style(node.kind, dim=True),
                         ),
                         file=output,
                     )
@@ -175,7 +175,7 @@ class OutputWriter_Plain(OutputWriter):
                         "- {id} ({title}) [{kind}]".format(
                             id=node.id,
                             title=node.title,
-                            kind=click.style(_node_kind_str(node), dim=True),
+                            kind=click.style(node.kind, dim=True),
                         ),
                         file=output,
                     )
@@ -216,9 +216,7 @@ class OutputWriter_INI(OutputWriter):
         output.write("{key} =\n".format(key=key))
         for node in nodes:
             output.write(
-                "  # {title} [{kind}]\n".format(
-                    title=node.title, kind=_node_kind_str(node)
-                )
+                "  # {title} [{kind}]\n".format(title=node.title, kind=node.kind)
             )
             output.write("  {id}\n".format(id=node.id))
 
@@ -336,13 +334,6 @@ class ContentList(object):
                     pick_nodes_queue.extend(node.children.all())
             elif node in pick_nodes:
                 self.__include_nodes.add(node)
-
-
-def _node_kind_str(node):
-    if node.kind == "topic":
-        return "topic - {children}".format(children=_get_leaf_nodes(node).count())
-    else:
-        return "{kind}".format(kind=node.kind)
 
 
 def _get_leaf_nodes(node):

--- a/tools/kolibri-listcontent.py
+++ b/tools/kolibri-listcontent.py
@@ -29,7 +29,7 @@ output_format_str_list = list(map(operator.attrgetter("name"), OutputFormat))
     "--format",
     "output_format_str",
     type=click.Choice(output_format_str_list, case_sensitive=False),
-    default=OutputFormat.INI.name,
+    default=OutputFormat.PLAIN.name,
     help="Use the specified output format",
 )
 @click.option(

--- a/tools/kolibri-listcontent.py
+++ b/tools/kolibri-listcontent.py
@@ -165,7 +165,10 @@ class OutputWriter_Plain(OutputWriter):
                     click.echo(
                         "+ {id} ({title}) [{kind}]".format(
                             id=node.id,
-                            title=click.style(node.title, bold=True),
+                            title=" / ".join(
+                                click.style(breadcrumb, bold=True)
+                                for breadcrumb in _node_breadcrumbs(node)
+                            ),
                             kind=click.style(node.kind, dim=True),
                         ),
                         file=output,
@@ -174,7 +177,10 @@ class OutputWriter_Plain(OutputWriter):
                     click.echo(
                         "- {id} ({title}) [{kind}]".format(
                             id=node.id,
-                            title=node.title,
+                            title=" / ".join(
+                                click.style(breadcrumb, bold=True)
+                                for breadcrumb in _node_breadcrumbs(node)
+                            ),
                             kind=click.style(node.kind, dim=True),
                         ),
                         file=output,
@@ -216,7 +222,9 @@ class OutputWriter_INI(OutputWriter):
         output.write("{key} =\n".format(key=key))
         for node in nodes:
             output.write(
-                "  # {title} [{kind}]\n".format(title=node.title, kind=node.kind)
+                "  # {title} [{kind}]\n".format(
+                    title=" / ".join(_node_breadcrumbs(node)), kind=node.kind
+                )
             )
             output.write("  {id}\n".format(id=node.id))
 
@@ -334,6 +342,15 @@ class ContentList(object):
                     pick_nodes_queue.extend(node.children.all())
             elif node in pick_nodes:
                 self.__include_nodes.add(node)
+
+
+def _node_breadcrumbs(node):
+    titles = [node.title]
+    while node.parent:
+        node = node.parent
+        if node.content_id != node.channel_id:
+            titles.append(node.title)
+    return reversed(titles)
 
 
 def _get_leaf_nodes(node):


### PR DESCRIPTION
Defaulting to `--format=ini` is convenient for documentation downstream, but if we would like this to end up as a management command in Kolibri itself in the future, it would be prudent to default to a more generally-useful output format.