### PR TITLE
Update to GNOME 41 runtime

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: org.learningequality.Kolibri
 runtime: org.gnome.Platform
-runtime-version: '40'
+runtime-version: '41'
 sdk: org.gnome.Sdk
 command: kolibri-gnome
 
@@ -92,7 +92,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d -m 755 /app/lib/python3.7/site-packages
-      - ln -s /app/lib/python3.8/site-packages/kolibri /app/lib/python3.7/site-packages/kolibri
+      - ln -s /app/lib/python3.9/site-packages/kolibri /app/lib/python3.7/site-packages/kolibri
 
   - name: python3-kolibri-cleanup
     buildsystem: simple
@@ -100,48 +100,48 @@ modules:
       - >
         ./cleanup-unused-locales.py
         -l /app/share/locale
-        -l /app/lib/python3.8/site-packages/kolibri/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/conf/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/admin/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/admindocs/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/auth/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/contenttypes/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/flatpages/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/gis/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/humanize/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/postgres/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/redirects/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/sessions/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django/contrib/sites/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/django_filters/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/kolibri_exercise_perseus_plugin/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/mptt/locale
-        /app/lib/python3.8/site-packages/kolibri/dist/pycountry/locales
-        /app/lib/python3.8/site-packages/kolibri/dist/rest_framework/locale
+        -l /app/lib/python3.9/site-packages/kolibri/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/conf/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/admin/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/admindocs/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/auth/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/contenttypes/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/flatpages/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/gis/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/humanize/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/postgres/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/redirects/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/sessions/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django/contrib/sites/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/django_filters/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/kolibri_exercise_perseus_plugin/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/mptt/locale
+        /app/lib/python3.9/site-packages/kolibri/dist/pycountry/locales
+        /app/lib/python3.9/site-packages/kolibri/dist/rest_framework/locale
       - >
         rm -rf
-        /app/lib/python3.8/site-packages/kolibri/dist/cext/cp27
-        /app/lib/python3.8/site-packages/kolibri/dist/cext/cp34/Windows
-        /app/lib/python3.8/site-packages/kolibri/dist/cext/cp35/Windows
-        /app/lib/python3.8/site-packages/kolibri/dist/cext/cp36/Windows
-        /app/lib/python3.8/site-packages/kolibri/dist/cext/cp37/Windows
+        /app/lib/python3.9/site-packages/kolibri/dist/cext/cp27
+        /app/lib/python3.9/site-packages/kolibri/dist/cext/cp34/Windows
+        /app/lib/python3.9/site-packages/kolibri/dist/cext/cp35/Windows
+        /app/lib/python3.9/site-packages/kolibri/dist/cext/cp36/Windows
+        /app/lib/python3.9/site-packages/kolibri/dist/cext/cp37/Windows
       - >
         rm -rf
-        /app/lib/python3.8/site-packages/kolibri/dist/cheroot/test
-        /app/lib/python3.8/site-packages/kolibri/dist/cherrypy/test
-        /app/lib/python3.8/site-packages/kolibri/dist/colorlog/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/Cryptodome/SelfTest
-        /app/lib/python3.8/site-packages/kolibri/dist/django_js_reverse/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/future/backports/test
-        /app/lib/python3.8/site-packages/kolibri/dist/future/moves/test
-        /app/lib/python3.8/site-packages/kolibri/dist/ipware/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/metaphone/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/more_itertools/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/py2only
-        /app/lib/python3.8/site-packages/kolibri/dist/pycountry/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/sqlalchemy/testing
-        /app/lib/python3.8/site-packages/kolibri/dist/tempora/tests
-        /app/lib/python3.8/site-packages/kolibri/dist/tzlocal/test_data
+        /app/lib/python3.9/site-packages/kolibri/dist/cheroot/test
+        /app/lib/python3.9/site-packages/kolibri/dist/cherrypy/test
+        /app/lib/python3.9/site-packages/kolibri/dist/colorlog/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/Cryptodome/SelfTest
+        /app/lib/python3.9/site-packages/kolibri/dist/django_js_reverse/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/future/backports/test
+        /app/lib/python3.9/site-packages/kolibri/dist/future/moves/test
+        /app/lib/python3.9/site-packages/kolibri/dist/ipware/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/metaphone/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/more_itertools/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/py2only
+        /app/lib/python3.9/site-packages/kolibri/dist/pycountry/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/sqlalchemy/testing
+        /app/lib/python3.9/site-packages/kolibri/dist/tempora/tests
+        /app/lib/python3.9/site-packages/kolibri/dist/tzlocal/test_data
     sources:
       - type: file
         path: cleanup-unused-locales.py

--- a/python3-kolibri-pytz.json
+++ b/python3-kolibri-pytz.json
@@ -2,7 +2,7 @@
     "name": "python3-pytz",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" pytz==2020.5 --upgrade --target=\"/app/lib/python3.8/site-packages/kolibri/dist/\""
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" pytz==2020.5 --upgrade --target=\"/app/lib/python3.9/site-packages/kolibri/dist/\""
     ],
     "sources": [
         {

--- a/python3-kolibri.json
+++ b/python3-kolibri.json
@@ -3,8 +3,8 @@
     "buildsystem": "simple",
     "build-commands": [
         "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} kolibri",
-        "patch /app/lib/python3.8/site-packages/kolibri/utils/server.py server.py.diff",
-        "patch /app/lib/python3.8/site-packages/kolibri/utils/cli.py cli.py.diff"
+        "patch /app/lib/python3.9/site-packages/kolibri/utils/server.py server.py.diff",
+        "patch /app/lib/python3.9/site-packages/kolibri/utils/cli.py cli.py.diff"
     ],
     "sources": [
         {


### PR DESCRIPTION
While the GNOME 40 runtime had Python 3.8, 41 has Python 3.9.

While the GNOME 40 runtime remains supported for another 6 months, Kolibri is the last app pre-installed in a size-constrained Endless OS disk image which uses the GNOME 40 runtime. Switching to 41 would mean we wouldn't need to pre-install the GNOME 40 runtime, and hence could avoid removing 1 or more apps from the image in question to fit the size budget.

Caveat reviewer: I've tested that this launches, but that's it. :)