### PR TITLE
Drop deprecated STATIC_USE_SYMLINKS setting

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -16,7 +16,6 @@ finish-args:
   - --system-talk-name=org.learningequality.Kolibri.Daemon
   - --env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri/data/kolibri
   - --env=KOLIBRI_HTTP_PORT=0
-  - --env=KOLIBRI_STATIC_USE_SYMLINKS=0
 
 add-extensions:
   org.learningequality.Kolibri.Content:


### PR DESCRIPTION
This setting has been dropped since Kolibri 0.15.0 and is currently a
no-op.

learningequality/kolibri#7792