### PR TITLE
Update kolibri-gnome to alpha version

### DIFF
--- a/modules/python3-kolibri-patches/0001-Allow-superuser-to-be-null-in-device-provision-API.patch
+++ b/modules/python3-kolibri-patches/0001-Allow-superuser-to-be-null-in-device-provision-API.patch
@@ -1,4 +1,4 @@
-From cdb3ae92eba9ee22ed5b264784e2c1bf72541666 Mon Sep 17 00:00:00 2001
+From 50a0da4c5f9294f18e76b61b9587d48c5ad3d22b Mon Sep 17 00:00:00 2001
 From: Dylan McCall <dylan@endlessos.org>
 Date: Thu, 2 Dec 2021 15:31:30 -0800
 Subject: [PATCH] Allow superuser to be null in device provision API
@@ -24,7 +24,7 @@ index 9103e49f93..c84de06979 100644
      allow_guest_access = serializers.BooleanField(allow_null=True)
 @@ -78,12 +78,16 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
              facility.dataset.save()
-
+ 
              # Create superuser
 -            superuser = FacilityUser.objects.create_superuser(
 -                validated_data["superuser"]["username"],
@@ -42,8 +42,9 @@ index 9103e49f93..c84de06979 100644
 +                )
 +            else:
 +                superuser = None
-
+ 
              # Create device settings
              language_id = validated_data.pop("language_id")
---
-2.33.1
+-- 
+2.37.2
+

--- a/modules/python3-kolibri.json
+++ b/modules/python3-kolibri.json
@@ -9,8 +9,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ec/ff/402890b344c01c195044c6de46bfc1499dcaa7b2c7f098ec995b31a08fa7/kolibri-0.15.7-py2.py3-none-any.whl",
-            "sha256": "8afb26d25c04f2c150efb38b84e1dfbf6912143f0e3f66709507ce1111b03bc4"
+            "url": "https://github.com/learningequality/kolibri/releases/download/v0.16.0-alpha5/kolibri-0.16.0a5-py2.py3-none-any.whl",
+            "sha256": "a758151820dd6fbbda67594d455947bc5a07acd46754cc0dcccbdca7b27bf318"
         },
         {
             "type": "dir",

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -54,8 +54,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/learningequality/kolibri-installer-gnome.git
-        # branch: master
-        tag: v2.1.4
+        branch: alpha
+        commit: c13f1d34ee4d736f703b4f9c2f17c256181df888
 
   - name: python3-kolibri-cleanup
     buildsystem: simple


### PR DESCRIPTION
This is anticipating a set of changes in endlessm/kolibri-installer-gnome#15 and endlessm/kolibri-installer-gnome#16.