### PR TITLE
Add python3-markdown

### DIFF
--- a/modules/python3-markdown.json
+++ b/modules/python3-markdown.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-markdown",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --ignore-installed --no-deps --no-index --no-build-isolation --find-links=\"file://${PWD}\" --target=\"${KOLIBRI_MODULE_PATH}/dist/\" markdown==3.3.7"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f3/df/ca72f352e15b6f8ce32b74af029f1189abffb906f7c137501ffe69c98a65/Markdown-3.3.7-py3-none-any.whl",
+            "sha256": "f5da449a6e1c989a4cea2631aa8ee67caa5a2ef855d551c88f9e309f4634c621"
+        }
+    ]
+}

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -12,7 +12,6 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
-  - --socket=x11
   - --system-talk-name=org.learningequality.Kolibri.Daemon
   - --env=KOLIBRI_HOME=~/.var/app/org.learningequality.Kolibri/data/kolibri
   - --env=KOLIBRI_HTTP_PORT=0

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -38,6 +38,7 @@ build-options:
 
 modules:
   - modules/iproute2.json
+  - modules/python3-markdown.json
   - modules/python3-kolibri.json
   - modules/python3-kolibri-pytz.json
   - modules/python3-kolibri-app-desktop-xdg-plugin.json


### PR DESCRIPTION
Kolibri requires python3-markdown < 3.4.0, which is no longer provided by the flatpak runtime.