### PR TITLE
Upgrade to GNOME 44 / GTK4

### DIFF
--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -63,7 +63,7 @@ modules:
       - type: git
         url: https://github.com/learningequality/kolibri-installer-gnome.git
         # branch: master
-        tag: v2.2.1
+        tag: v2.3.1
 
   - name: python3-kolibri-cleanup
     buildsystem: simple

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -122,18 +122,6 @@ modules:
       - type: file
         path: cleanup-unused-locales.py
 
-  - name: migrate-kolibri-python37-python39
-    buildsystem: simple
-    build-commands:
-      - install -d -m 755 /app/lib/python3.7/site-packages
-      - ln -s /app/lib/python3.9/site-packages/kolibri /app/lib/python3.7/site-packages/kolibri
-
-  - name: migrate-kolibri-python38-python39
-    buildsystem: simple
-    build-commands:
-      - install -d -m 755 /app/lib/python3.8/site-packages
-      - ln -s /app/lib/python3.9/site-packages/kolibri /app/lib/python3.8/site-packages/kolibri
-
   - name: migrate-kolibri-daemon-path
     buildsystem: simple
     build-commands:

--- a/org.learningequality.Kolibri.yaml
+++ b/org.learningequality.Kolibri.yaml
@@ -1,7 +1,7 @@
 ---
 app-id: org.learningequality.Kolibri
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: kolibri-gnome
 
@@ -40,7 +40,7 @@ cleanup-commands:
 
 build-options:
   env:
-    KOLIBRI_MODULE_PATH: /app/lib/python3.9/site-packages/kolibri
+    KOLIBRI_MODULE_PATH: /app/lib/python3.10/site-packages/kolibri
 
 modules:
   - modules/iproute2.json
@@ -116,7 +116,7 @@ modules:
         ${KOLIBRI_MODULE_PATH}/dist/tzlocal/test_data
       - >
         find
-        /app/lib/python3.9 /app/share/kolibri-home-template
+        /app/lib/python3.10 /app/share/kolibri-home-template
         -name '*.js.map' -exec rm '{}' '+'
     sources:
       - type: file


### PR DESCRIPTION
Do that by bumping to kolibri-gnome v2.3.0 and the platform to GNOME 44;

This is just https://github.com/flathub/org.learningequality.Kolibri/pull/62 with an extra commit, but I couldn't push to that branch.