### PR TITLE
Update kolibri-app-desktop-xdg-plugin and Pillow

### DIFF
--- a/modules/python3-kolibri-app-desktop-xdg-plugin.json
+++ b/modules/python3-kolibri-app-desktop-xdg-plugin.json
@@ -2,18 +2,28 @@
     "name": "python3-kolibri-app-desktop-xdg-plugin",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} kolibri-app-desktop-xdg-plugin"
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --use-pep517 kolibri-app-desktop-xdg-plugin"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/90/d4/a7c9b6c5d176654aa3dbccbfd0be4fd3a263355dc24122a5f1937bdc2689/Pillow-8.3.2.tar.gz",
-            "sha256": "dde3f3ed8d00c72631bc19cbfff8ad3b6215062a5eed402381ad365f82f0c18c"
+            "url": "https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl",
+            "sha256": "b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/3e/b8/46e65ec41b08c8f78a5e571357d6a0634187286f6ba558c447fb99f4512c/kolibri_app_desktop_xdg_plugin-1.1.4-py2.py3-none-any.whl",
-            "sha256": "16d16a21c55cae262dbf587e43815af1646b3b7dac70f07bf1d0c412833911aa"
+            "url": "https://files.pythonhosted.org/packages/c7/c3/55076fc728723ef927521abaa1955213d094933dc36d4a2008d5101e1af5/wheel-0.42.0-py3-none-any.whl",
+            "sha256": "177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/80/d7/c4b258c9098b469c4a4e77b0a99b5f4fd21e359c2e486c977d231f52fc71/Pillow-10.1.0.tar.gz",
+            "sha256": "e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/44/01/a40f3823fc367731e5cd7a90306b0cc3af080b1e13f59fd66efb3ff7bec4/kolibri_app_desktop_xdg_plugin-1.2.0-py3-none-any.whl",
+            "sha256": "d689e7cdcdad49a2897fa1ce9069ff9d57e375c7918a4e5b27bb6fbe4d3e5859"
         }
     ]
 }


### PR DESCRIPTION
A new release of kolibri-app-desktop-xdg-plugin was made to update the Pillow dependency.