### PR TITLE
Update iproute2, python3-kolibri and 2 more modules

### DIFF
--- a/modules/iproute2.json
+++ b/modules/iproute2.json
@@ -10,12 +10,12 @@
         {
             "type": "git",
             "url": "https://git.kernel.org/pub/scm/network/iproute2/iproute2.git",
-            "tag": "v6.11.0",
+            "tag": "v6.12.0",
             "x-checker-data": {
                 "type": "git",
                 "tag-pattern": "^v([\\d.]+)$"
             },
-            "commit": "b19d4d6eef2f97e55d03eb7f1f2e528def72296d"
+            "commit": "742fb8a25c8740a1b93251ed33da08a60b8353aa"
         }
     ]
 }

--- a/modules/python3-kolibri-app-desktop-xdg-plugin.json
+++ b/modules/python3-kolibri-app-desktop-xdg-plugin.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ff/ae/f19306b5a221f6a436d8f2238d5b80925004093fa3edea59835b514d9057/setuptools-75.1.0-py3-none-any.whl",
-            "sha256": "35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2",
+            "url": "https://files.pythonhosted.org/packages/55/21/47d163f615df1d30c094f6c8bbb353619274edccf0327b185cc2493c2c33/setuptools-75.6.0-py3-none-any.whl",
+            "sha256": "ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "setuptools",
@@ -17,8 +17,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/1b/d1/9babe2ccaecff775992753d8686970b1e2755d21c8a63be73aba7a4e7d77/wheel-0.44.0-py3-none-any.whl",
-            "sha256": "2376a90c98cc337d18623527a97c31797bd02bad0033d41547043a1cbfbe448f",
+            "url": "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl",
+            "sha256": "708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "wheel",

--- a/modules/python3-kolibri.json
+++ b/modules/python3-kolibri.json
@@ -8,8 +8,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/28/d3/47b937cfb47d9e1871d29f4e1155dd7d2a9b5a1ce2666dd59bd0387cd053/kolibri-0.17.2-py2.py3-none-any.whl",
-            "sha256": "ed1ccacc5ead261b582370eaac155abe6111b150a1639b509f0b97babff9c8aa",
+            "url": "https://files.pythonhosted.org/packages/7b/a1/3ffe45a7247c1f811db09809e42de725cf564877f879fdbe99bdfda5531f/kolibri-0.17.3-py2.py3-none-any.whl",
+            "sha256": "655f18123925472d1806c9cc04469fac548fb90a1e3d1ba5b7fb6a7649b22efd",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "kolibri",

--- a/modules/python3-setproctitle.json
+++ b/modules/python3-setproctitle.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ff/e1/b16b16a1aa12174349d15b73fd4b87e641a8ae3fb1163e80938dbbf6ae98/setproctitle-1.3.3.tar.gz",
-            "sha256": "c913e151e7ea01567837ff037a23ca8740192880198b7fbb90b16d181607caae",
+            "url": "https://files.pythonhosted.org/packages/ae/4e/b09341b19b9ceb8b4c67298ab4a08ef7a4abdd3016c7bb152e9b6379031d/setproctitle-1.3.4.tar.gz",
+            "sha256": "3b40d32a3e1f04e94231ed6dfee0da9e43b4f9c6b5450d53e6dd7754c34e0c50",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "setproctitle"


### PR DESCRIPTION
iproute2: Update iproute2.git to 6.12.0
python3-kolibri: Update kolibri-0.17.2-py2.py3-none-any.whl to 0.17.3
python3-kolibri-app-desktop-xdg-plugin: Update setuptools-75.1.0-py3-none-any.whl to 75.6.0
python3-kolibri-app-desktop-xdg-plugin: Update wheel-0.44.0-py3-none-any.whl to 0.45.1
python3-setproctitle: Update setproctitle-1.3.3.tar.gz to 1.3.4