### PR TITLE
Disable data checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "disable-external-data-checker": true
+}


### PR DESCRIPTION
Flathubbot has been creating too much PR without any success.

There are only 2 successful PR against 66 failed PR.

I think it would be good to close automatic PR creation until the data-checker optimizations are complete.

See: https://github.com/flathub/org.learningequality.Kolibri/pulls?page=1&q=is%3Apr+is%3Aclosed+author%3Aflathubbot